### PR TITLE
Improvements

### DIFF
--- a/src/Command/DatabaseMigrationCreateCommand.php
+++ b/src/Command/DatabaseMigrationCreateCommand.php
@@ -32,7 +32,11 @@ class DatabaseMigrationCreateCommand extends AbstractCommand implements EntityMa
         $timestamp = time();
         $template  = $this->buildTemplate($timestamp);
 
-        $migrationsDir = __DIR__ . '/../../../src/Migration';
+        if (!is_dir('./../src/Migration')) {
+            mkdir('./../src/Migration');
+        }
+
+        $migrationsDir = realpath('./../src/Migration');
         $filename      = sprintf('Migration%s.php', $timestamp);
 
         file_put_contents(sprintf('%s/%s', $migrationsDir, $filename), $template);
@@ -53,8 +57,8 @@ class DatabaseMigrationCreateCommand extends AbstractCommand implements EntityMa
 
 namespace App\Migration;
 
-use PDO;
-use Faulancer\Migration\AbstractMigration;
+use \PDO;
+use Faulancer\Database\Migration\AbstractMigration;
 
 class Migration{$timestamp} extends AbstractMigration
 {

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -66,7 +66,9 @@ class ErrorController extends AbstractController implements ObserverAwareInterfa
             ['file' => $file, 'line' => $line]
         );
 
-        throw new FrameworkException($message, $context, $code);
+        $exception = new FrameworkException($message, $context, $code);
+
+        return $this->onException($exception);
     }
 
     /**

--- a/src/Database/EntityManager.php
+++ b/src/Database/EntityManager.php
@@ -13,9 +13,11 @@ class EntityManager extends ORMEntityManager
      */
     public function __construct(Config $config)
     {
-        $options = [
-            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'
-        ];
+        if (defined('PDO::MYSQL_ATTR_INIT_COMMAND')) {
+            $options = [
+                \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'
+            ];
+        }
         $dbConfig = $config->get('app:database');
         $dsn      = $dbConfig['dsn'] ?? null;
         $user     = $dbConfig['user'] ?? null;

--- a/src/Form/Type/Button.php
+++ b/src/Form/Type/Button.php
@@ -32,7 +32,7 @@ class Button extends AbstractType
                 continue;
             }
 
-            $result .= sprintf(' %s="%s"', $attribute, $this->getTranslator()->translate($value));
+            $result .= sprintf(' %s="%s', $attribute, $this->getTranslator()->translate($value));
         }
 
         $result .= '">' . $this->getTranslator()->translate($this->definition['text']) . '</button>';

--- a/src/Form/Type/Csrf.php
+++ b/src/Form/Type/Csrf.php
@@ -26,7 +26,11 @@ class Csrf extends AbstractType
      */
     public function render(): string
     {
-        return sprintf('<input type="hidden" name="csrf" value="%s" />', $this->definition['value']);
+        return sprintf(
+            '<input type="hidden" name="csrf" data-id="%s" value="%s" />',
+            $this->definition['data-id'] ?? null,
+            $this->definition['value']
+        );
     }
 
 }

--- a/src/Http/JsonResponse.php
+++ b/src/Http/JsonResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Faulancer\Http;
+
+class JsonResponse extends Response
+{
+    public function __construct(int $status = 200, array $headers = [], $body = null, string $version = '1.1', string $reason = null)
+    {
+        $headers['Content-Type'] = 'application/json';
+        parent::__construct($status, $headers, $body, $version, $reason);
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -154,11 +154,15 @@ class Kernel
                 ? $errorController->onException($e)
                 : $e->getMessage();
         } catch (\ParseError | \Error $p) {
-            var_dump("Hallo");die();
             header('HTTP/2 500 Server error');
             echo null !== $errorController
                 ? $errorController->onError($p->getCode(), $p->getMessage(), $p->getFile(), $p->getLine())
                 : $p->getMessage();
+        } catch (\Throwable $t) {
+            header('HTTP/2 500 Server error');
+            echo null !== $errorController
+                ? $errorController->onError($t->getCode(), $t->getMessage(), $t->getFile(), $t->getLine())
+                : $t->getMessage();
         }
 
     }

--- a/src/Service/Translator.php
+++ b/src/Service/Translator.php
@@ -59,8 +59,8 @@ class Translator implements ConfigAwareInterface, LoggerAwareInterface, Observer
 
         $translatedString = $this->translationData[$translationKey] ?? null;
 
-        if (null === $translatedString) {
-            $this->getObserver()->notify(new TranslationMissingEvent($translationKey, $this->translationData));
+        if (null !== $translationKey && null === $translatedString) {
+            $this->getObserver()->notify(new TranslationMissingEvent($translationKey, $this->translationData ?? []));
             return $translationKey;
         }
 


### PR DESCRIPTION
- The command which creates migrations is now able to create it's migration directory
- The ErrorController can display errors more structured even when the Renderer fails to initialize
- Adjusted the EntityManager to work without the MySQL Extension installed
- In the FormBuilder the action from the definition is now respected
- Removed obsolete quote in Button element
- Improved CSRF integration to be able to validate forms send with Xhr
- Added a JsonResponse class
- Added another catch directive to the kernel, to be able to catch even the tiniest exception
- Fixed translator as it throws an error when no translation files are present